### PR TITLE
build: sync SDK version to v1.3.3 with published packages

### DIFF
--- a/androidsdk/build.gradle.kts
+++ b/androidsdk/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     group = "com.accruesavings.androidsdk"
-    version = "v1.3.1"
+    version = "v1.3.3"
     namespace = "com.accruesavings.androidsdk"
     compileSdk = 34
 
@@ -89,7 +89,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.accruesavings"
             artifactId = "androidsdk"
-            version = "v1.3.1"
+            version = "v1.3.3"
 
             afterEvaluate {
                 from(components["release"])
@@ -116,7 +116,7 @@ publishing {
 //
 //                groupId = "com.github.accrue-savings"
 //                artifactId = "android-sdk"
-//                version = "v1.3.1"
+//                version = "v1.3.3"
 //
 //                afterEvaluate {
 //                    from(components["release"])

--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueContextData.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueContextData.kt
@@ -21,7 +21,7 @@ data class AccrueSettingsData(
 
 data class AccrueDeviceContextData(
     val sdk: String = "Android",
-    val sdkVersion: String? = "v1.3.1",
+    val sdkVersion: String? = "v1.3.3",
     val brand: String? = Build.BRAND,
     val deviceName: String? = Build.DEVICE,
     val deviceType: String? = Build.PRODUCT,


### PR DESCRIPTION
Align android block, Maven publication, and AccrueContextData sdkVersion with the latest version on GitHub Packages.

Made-with: Cursor