### PR TITLE
fix(release): block stale-tag downgrade; restore v1.3.3 in source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 17
@@ -88,8 +89,31 @@ jobs:
       - name: Update Package Version
         id: bump
         run: |
+          set -euo pipefail
           NEXT_VERSION="${{ steps.semver.outputs.next }}"
-          echo "Updating version to ${NEXT_VERSION}"
+          CURRENT_TAG="${{ steps.semver.outputs.current }}"
+          echo "semver latest tag (current): ${CURRENT_TAG}"
+          echo "semver calculated next release: ${NEXT_VERSION}"
+
+          # android {} block version (first matching line — must stay before publishing {} block).
+          FILE_VERSION=$(grep -m1 -E '^\s+version = "v[0-9]+\.[0-9]+\.[0-9]+"' androidsdk/build.gradle.kts | sed -E 's/.*"(v[0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
+          if [[ -z "${FILE_VERSION}" ]]; then
+            echo "::error::Could not parse SDK version from androidsdk/build.gradle.kts (android block)."
+            exit 1
+          fi
+          echo "version currently in androidsdk/build.gradle.kts: ${FILE_VERSION}"
+
+          # If git tags lag GitHub Packages, semver keeps an old baseline while source is newer.
+          # Applying that "next" would downgrade the repo and republish an existing artifact (409).
+          NEXT_S="${NEXT_VERSION#v}"
+          FILE_S="${FILE_VERSION#v}"
+          if dpkg --compare-versions "${NEXT_S}" lt "${FILE_S}"; then
+            echo "::error::Release version ${NEXT_VERSION} is behind the version declared in source (${FILE_VERSION})."
+            echo "Push git tags on main for each version already published to GitHub Packages (e.g. v1.3.2, v1.3.3) so the latest tag matches reality, then merge or re-run this workflow."
+            exit 1
+          fi
+
+          echo "Updating version files to ${NEXT_VERSION}"
 
           # Update androidsdk/build.gradle.kts - android block version
           sed -i '/^android {/,/^}/s/version = "v[0-9]*\.[0-9]*\.[0-9]*"/version = "'"${NEXT_VERSION}"'"/' androidsdk/build.gradle.kts

--- a/androidsdk/build.gradle.kts
+++ b/androidsdk/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 android {
     group = "com.accruesavings.androidsdk"
-    version = "v1.3.1"
+    version = "v1.3.3"
     namespace = "com.accruesavings.androidsdk"
     compileSdk = 34
 
@@ -89,7 +89,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.accruesavings"
             artifactId = "androidsdk"
-            version = "v1.3.1"
+            version = "v1.3.3"
 
             afterEvaluate {
                 from(components["release"])
@@ -116,7 +116,7 @@ publishing {
 //
 //                groupId = "com.github.accrue-savings"
 //                artifactId = "android-sdk"
-//                version = "v1.3.1"
+//                version = "v1.3.3"
 //
 //                afterEvaluate {
 //                    from(components["release"])

--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueContextData.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueContextData.kt
@@ -21,7 +21,7 @@ data class AccrueSettingsData(
 
 data class AccrueDeviceContextData(
     val sdk: String = "Android",
-    val sdkVersion: String? = "v1.3.1",
+    val sdkVersion: String? = "v1.3.3",
     val brand: String? = Build.BRAND,
     val deviceName: String? = Build.DEVICE,
     val deviceType: String? = Build.PRODUCT,


### PR DESCRIPTION
- Compare semver next to android.version before sed; fail if tags lag packages.
- fetch-tags on checkout.
- Restore v1.3.3 in build.gradle.kts and AccrueContextData (reverted by CI to v1.3.1).

Made-with: Cursor