### PR TITLE
feat: resolve widget URLs remotely

### DIFF
--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueSdkUrls.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueSdkUrls.kt
@@ -1,0 +1,96 @@
+package com.accruesavings.androidsdk
+
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+internal data class AccrueSdkUrlConfig(
+    val production: String,
+    val sandbox: String
+)
+
+internal object AccrueSdkUrls {
+    private const val TAG = "AccrueSdkUrls"
+    private const val SDK_URLS_ENDPOINT = "https://www.byaccrue.com/sdk-urls"
+    private const val WIDGET_PATH = "webview"
+    private const val CONNECT_TIMEOUT_MS = 5000
+    private const val READ_TIMEOUT_MS = 5000
+    private const val FALLBACK_PRODUCTION_URL = "https://embed.accruesavings.com/webview"
+    private const val FALLBACK_SANDBOX_URL = "https://embed-sandbox.accruesavings.com/webview"
+
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
+
+    fun fetchWidgetUrl(
+        isSandbox: Boolean,
+        callback: (Result<String>) -> Unit
+    ) {
+        executor.execute {
+            val result = runCatching {
+                val config = fetchConfig()
+                widgetUrl(config, isSandbox)
+            }
+
+            mainHandler.post {
+                callback(result)
+            }
+        }
+    }
+
+    fun parseConfig(responseBody: String): AccrueSdkUrlConfig {
+        val json = JSONObject(responseBody)
+        return AccrueSdkUrlConfig(
+            production = json.getString("production"),
+            sandbox = json.getString("sandbox")
+        )
+    }
+
+    fun widgetUrl(config: AccrueSdkUrlConfig, isSandbox: Boolean): String {
+        val baseUrl = if (isSandbox) config.sandbox else config.production
+        return appendWidgetPath(baseUrl)
+    }
+
+    fun fallbackWidgetUrl(isSandbox: Boolean): String {
+        return if (isSandbox) FALLBACK_SANDBOX_URL else FALLBACK_PRODUCTION_URL
+    }
+
+    fun appendWidgetPath(baseUrl: String): String {
+        val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
+        require(normalizedBaseUrl.isNotEmpty()) { "SDK widget base URL is empty" }
+
+        return if (normalizedBaseUrl.endsWith("/$WIDGET_PATH")) {
+            normalizedBaseUrl
+        } else {
+            "$normalizedBaseUrl/$WIDGET_PATH"
+        }
+    }
+
+    private fun fetchConfig(): AccrueSdkUrlConfig {
+        val connection = URL(SDK_URLS_ENDPOINT).openConnection() as HttpURLConnection
+
+        return try {
+            connection.requestMethod = "GET"
+            connection.connectTimeout = CONNECT_TIMEOUT_MS
+            connection.readTimeout = READ_TIMEOUT_MS
+
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                throw IllegalStateException("SDK URL config request failed with HTTP $responseCode")
+            }
+
+            connection.inputStream.bufferedReader().use { reader ->
+                parseConfig(reader.readText())
+            }
+        } catch (error: Exception) {
+            Log.e(TAG, "Failed to fetch SDK URL config", error)
+            throw error
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueWallet.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueWallet.kt
@@ -139,10 +139,14 @@ class AccrueWallet : Fragment() {
                 throw IllegalStateException(errorMsg)
             }
 
-        val builtUrl = buildURL(isSandbox, url, merchantIdValue)
-        Log.v(TAG, "builtUrl=$builtUrl")
         // Create AccrueWebView programmatically
-        val accrueWebView = AccrueWebView(requireContext(), url = builtUrl, contextData, onAction)
+        val accrueWebView = AccrueWebView(
+            requireContext(),
+            url = "about:blank",
+            contextData,
+            onAction,
+            shouldLoadImmediately = false
+        )
         webView = accrueWebView
         
         // Initialize Provisioning if not already pre-initialized
@@ -163,17 +167,43 @@ class AccrueWallet : Fragment() {
         )
         accrueWebView.layoutParams = layoutParams
 
+        loadWidget(accrueWebView, merchantIdValue)
+
         // Return the webView as the root view
         return accrueWebView
     }
 
-    private fun buildURL(isSandbox: Boolean, url: String?, merchantIdParam: String): String {
-        val apiBaseUrl = when {
-            url != null -> url
-            isSandbox -> AppConstants.sandboxUrl
-            else -> AppConstants.productionUrl
+    private fun loadWidget(accrueWebView: AccrueWebView, merchantIdValue: String) {
+        val customUrl = url?.takeIf { it.isNotBlank() }
+        if (customUrl != null) {
+            val builtUrl = buildURL(customUrl, merchantIdValue)
+            Log.v(TAG, "builtUrl=$builtUrl")
+            accrueWebView.loadWidgetUrl(builtUrl)
+            return
         }
 
+        AccrueSdkUrls.fetchWidgetUrl(isSandbox) { result ->
+            if (webView !== accrueWebView) {
+                return@fetchWidgetUrl
+            }
+
+            result
+                .onSuccess { widgetUrl ->
+                    val builtUrl = buildURL(widgetUrl, merchantIdValue)
+                    Log.v(TAG, "builtUrl=$builtUrl")
+                    accrueWebView.loadWidgetUrl(builtUrl)
+                }
+                .onFailure { error ->
+                    Log.e(TAG, "Failed to resolve Accrue widget URL", error)
+                    val fallbackUrl = AccrueSdkUrls.fallbackWidgetUrl(isSandbox)
+                    val builtUrl = buildURL(fallbackUrl, merchantIdValue)
+                    Log.v(TAG, "builtUrl=$builtUrl")
+                    accrueWebView.loadWidgetUrl(builtUrl)
+                }
+        }
+    }
+
+    private fun buildURL(apiBaseUrl: String, merchantIdParam: String): String {
         val uri = Uri.parse(apiBaseUrl).buildUpon()
             .appendQueryParameter("merchantId", merchantIdParam)
 

--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueWebView.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/AccrueWebView.kt
@@ -65,7 +65,8 @@ class AccrueWebView @JvmOverloads constructor(
     context: Context,
     private var url: String,
     private var contextData: AccrueContextData? = null,
-    private var onAction: Map<AccrueAction, () -> Unit> = emptyMap()
+    private var onAction: Map<AccrueAction, () -> Unit> = emptyMap(),
+    private val shouldLoadImmediately: Boolean = true
 ) : WebView(context) {
 
     private var webAppInterface: WebAppInterface? = null
@@ -104,8 +105,14 @@ class AccrueWebView @JvmOverloads constructor(
         webAppInterface = WebAppInterface(this.onAction, contextData, this)
         addJavascriptInterface(webAppInterface!!, AccrueWebEvents.eventHandlerName)
 
-        // Load URL
-        loadUrl(url)
+        if (shouldLoadImmediately) {
+            loadWidgetUrl(url)
+        }
+    }
+
+    internal fun loadWidgetUrl(widgetUrl: String) {
+        url = widgetUrl
+        loadUrl(widgetUrl)
     }
 
     private class WebAppInterface(

--- a/androidsdk/src/main/java/com/accruesavings/androidsdk/Constants.kt
+++ b/androidsdk/src/main/java/com/accruesavings/androidsdk/Constants.kt
@@ -1,9 +1,6 @@
 package com.accruesavings.androidsdk
 
 object AppConstants {
-    // Mocked testing environment
-    const val sandboxUrl: String = "https://embed-sandbox.accruesavings.com/webview"
-    const val productionUrl: String = "https://embed.accruesavings.com/webview"
     // Mocked merchantId
     const val merchantId: String = "08b13e48-06be-488f-9a93-91f59d94f30d"
     const val redirectionToken = "redirection-token"

--- a/androidsdk/src/test/java/com/accruesavings/androidsdk/AccrueSdkUrlsTest.kt
+++ b/androidsdk/src/test/java/com/accruesavings/androidsdk/AccrueSdkUrlsTest.kt
@@ -1,0 +1,56 @@
+package com.accruesavings.androidsdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccrueSdkUrlsTest {
+    @Test
+    fun widgetUrl_appendsWebviewPathForProduction() {
+        val config = AccrueSdkUrlConfig(
+            production = "https://production.example.com",
+            sandbox = "https://sandbox.example.com"
+        )
+
+        assertEquals(
+            "https://production.example.com/webview",
+            AccrueSdkUrls.widgetUrl(config, isSandbox = false)
+        )
+    }
+
+    @Test
+    fun widgetUrl_appendsWebviewPathForSandbox() {
+        val config = AccrueSdkUrlConfig(
+            production = "https://production.example.com",
+            sandbox = "https://sandbox.example.com"
+        )
+
+        assertEquals(
+            "https://sandbox.example.com/webview",
+            AccrueSdkUrls.widgetUrl(config, isSandbox = true)
+        )
+    }
+
+    @Test
+    fun appendWidgetPath_doesNotDuplicateExistingWebviewPath() {
+        assertEquals(
+            "https://production.example.com/webview",
+            AccrueSdkUrls.appendWidgetPath("https://production.example.com/webview")
+        )
+    }
+
+    @Test
+    fun fallbackWidgetUrl_returnsPreviousProductionUrl() {
+        assertEquals(
+            "https://embed.accruesavings.com/webview",
+            AccrueSdkUrls.fallbackWidgetUrl(isSandbox = false)
+        )
+    }
+
+    @Test
+    fun fallbackWidgetUrl_returnsPreviousSandboxUrl() {
+        assertEquals(
+            "https://embed-sandbox.accruesavings.com/webview",
+            AccrueSdkUrls.fallbackWidgetUrl(isSandbox = true)
+        )
+    }
+}


### PR DESCRIPTION
Fetch widget host URLs from the sdk-urls endpoint before mounting the wallet webview, with env-based fallback URLs and resolution logging.

This will allow for switching between old sandbox/prod apps/embed and new embed in apps/app just by changing a worker in Cloudflare without needing to deploy the apps. But this must not break current functionality because if it does its a pickle. :)

Co-authored-by: Codex